### PR TITLE
Add Elasticsearch indexing and fallback search

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,10 @@
       <artifactId>spring-boot-starter-batch</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-elasticsearch</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>runtime</scope>

--- a/src/main/java/com/assignment/phoneinventory/ElasticsearchConfig.java
+++ b/src/main/java/com/assignment/phoneinventory/ElasticsearchConfig.java
@@ -1,0 +1,48 @@
+package com.assignment.phoneinventory;
+
+import javax.annotation.PostConstruct;
+
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.RestClients;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.ElasticsearchRestTemplate;
+import org.springframework.data.elasticsearch.core.IndexOperations;
+
+import com.assignment.phoneinventory.es.TelephoneNumberDocument;
+
+@Configuration
+public class ElasticsearchConfig {
+
+    @Value("${spring.elasticsearch.uris:localhost:9200}")
+    private String esUrl;
+
+    @Bean
+    public RestHighLevelClient elasticsearchClient() {
+        ClientConfiguration config = ClientConfiguration.builder()
+                .connectedTo(esUrl)
+                .build();
+        return RestClients.create(config).rest();
+    }
+
+    @Bean
+    public ElasticsearchOperations elasticsearchTemplate(RestHighLevelClient client) {
+        return new ElasticsearchRestTemplate(client);
+    }
+
+    @Autowired
+    private ElasticsearchOperations operations;
+
+    @PostConstruct
+    public void createIndex() {
+        IndexOperations indexOps = operations.indexOps(TelephoneNumberDocument.class);
+        if (!indexOps.exists()) {
+            indexOps.create();
+            indexOps.putMapping(indexOps.createMapping());
+        }
+    }
+}

--- a/src/main/java/com/assignment/phoneinventory/PhoneInventoryStarter.java
+++ b/src/main/java/com/assignment/phoneinventory/PhoneInventoryStarter.java
@@ -2,8 +2,10 @@ package com.assignment.phoneinventory;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication
+@EnableAsync
 public class PhoneInventoryStarter {
     public static void main(String[] args) {
         SpringApplication.run(PhoneInventoryStarter.class, args);

--- a/src/main/java/com/assignment/phoneinventory/controller/TelephoneController.java
+++ b/src/main/java/com/assignment/phoneinventory/controller/TelephoneController.java
@@ -6,6 +6,7 @@ import com.assignment.phoneinventory.dto.PageResponse;
 import com.assignment.phoneinventory.mapper.JobStatusMapper;
 import com.assignment.phoneinventory.service.BatchJobService;
 import com.assignment.phoneinventory.service.TelephoneService;
+import com.assignment.phoneinventory.service.TelephoneSearchService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.batch.core.Job;
@@ -28,6 +29,7 @@ import java.time.Duration;
 public class TelephoneController {
 
     private final TelephoneService service;
+    private final TelephoneSearchService searchService;
     private final JobLauncher jobLauncher;
     private final Job importJob;
     private final JobExplorer jobExplorer;
@@ -36,8 +38,9 @@ public class TelephoneController {
 
 
     @Autowired
-    public TelephoneController(TelephoneService service, JobLauncher jobLauncher, Job importJob, JobExplorer jobExplorer, JobStatusMapper jobStatusMapper, BatchJobService batchJobService) {
+    public TelephoneController(TelephoneService service, TelephoneSearchService searchService, JobLauncher jobLauncher, Job importJob, JobExplorer jobExplorer, JobStatusMapper jobStatusMapper, BatchJobService batchJobService) {
         this.service = service;
+        this.searchService = searchService;
         this.jobLauncher = jobLauncher;
         this.importJob = importJob;
         this.jobExplorer = jobExplorer;
@@ -46,7 +49,7 @@ public class TelephoneController {
     }
 
     @GetMapping
-    @Operation(summary = "Search telephone numbers with pagination")
+    @Operation(summary = "Search telephone numbers with pagination (supports fuzzy and wildcard)")
     public PageResponse<TelephoneNumber> search(
             @RequestParam(required = false) String countryCode,
             @RequestParam(required = false) String areaCode,
@@ -54,8 +57,10 @@ public class TelephoneController {
             @RequestParam(required = false) String contains,
             @RequestParam(required = false) TelephoneNumber.Status status,
             @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size) {
-        return service.search(countryCode, areaCode, prefix, contains, status, page, size);
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "false") boolean fuzzy,
+            @RequestParam(defaultValue = "false") boolean wildcard) {
+        return searchService.search(countryCode, areaCode, prefix, contains, status, page, size, fuzzy, wildcard);
     }
 
     @PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/assignment/phoneinventory/dao/TelephoneNumberDao.java
+++ b/src/main/java/com/assignment/phoneinventory/dao/TelephoneNumberDao.java
@@ -1,6 +1,8 @@
 package com.assignment.phoneinventory.dao;
 
 import com.assignment.phoneinventory.domain.TelephoneNumber;
+import com.assignment.phoneinventory.es.TelephoneNumberChangedEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
@@ -20,9 +22,11 @@ import static com.assignment.phoneinventory.dao.TelephoneSql.*;
 public class TelephoneNumberDao {
 
     private final JdbcTemplate jdbc;
+    private final ApplicationEventPublisher events;
 
-    public TelephoneNumberDao(JdbcTemplate jdbc) {
+    public TelephoneNumberDao(JdbcTemplate jdbc, ApplicationEventPublisher events) {
         this.jdbc = jdbc;
+        this.events = events;
     }
 
     private static final RowMapper<TelephoneNumber> ROW_MAPPER = new RowMapper<TelephoneNumber>() {
@@ -116,7 +120,7 @@ public class TelephoneNumberDao {
 
     public int updateWithVersion(Long id, long expectedVersion, TelephoneNumber newState) {
         Timestamp reserved = newState.getReservedUntil() == null ? null : Timestamp.from(newState.getReservedUntil());
-        return jdbc.update(
+        int rows = jdbc.update(
                 UPDATE_WITH_VERSION,
                 newState.getStatus().name(),
                 newState.getAllocatedUserId(),
@@ -124,6 +128,11 @@ public class TelephoneNumberDao {
                 id,
                 expectedVersion
         );
+        if (rows > 0) {
+            newState.setId(id);
+            events.publishEvent(new TelephoneNumberChangedEvent(newState));
+        }
+        return rows;
     }
 
     public boolean existsByNumber(String number) {
@@ -132,7 +141,7 @@ public class TelephoneNumberDao {
     }
 
     public int insert(TelephoneNumber t) {
-        return jdbc.update(
+        int rows = jdbc.update(
                 INSERT_ROW,
                 t.getNumber(),
                 t.getCountryCode(),
@@ -145,6 +154,10 @@ public class TelephoneNumberDao {
                 // Persist normalized digits if your INSERT includes it
                 t.getNumberDigits()
         );
+        if (rows > 0) {
+            events.publishEvent(new TelephoneNumberChangedEvent(t));
+        }
+        return rows;
     }
 
     /**

--- a/src/main/java/com/assignment/phoneinventory/es/TelephoneIndexListener.java
+++ b/src/main/java/com/assignment/phoneinventory/es/TelephoneIndexListener.java
@@ -1,0 +1,22 @@
+package com.assignment.phoneinventory.es;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+
+@Component
+public class TelephoneIndexListener {
+
+    private final ElasticsearchOperations operations;
+
+    public TelephoneIndexListener(ElasticsearchOperations operations) {
+        this.operations = operations;
+    }
+
+    @Async
+    @EventListener
+    public void onTelephoneChanged(TelephoneNumberChangedEvent event) {
+        operations.save(TelephoneNumberDocument.from(event.getNumber()));
+    }
+}

--- a/src/main/java/com/assignment/phoneinventory/es/TelephoneNumberChangedEvent.java
+++ b/src/main/java/com/assignment/phoneinventory/es/TelephoneNumberChangedEvent.java
@@ -1,0 +1,15 @@
+package com.assignment.phoneinventory.es;
+
+import com.assignment.phoneinventory.domain.TelephoneNumber;
+
+public class TelephoneNumberChangedEvent {
+    private final TelephoneNumber number;
+
+    public TelephoneNumberChangedEvent(TelephoneNumber number) {
+        this.number = number;
+    }
+
+    public TelephoneNumber getNumber() {
+        return number;
+    }
+}

--- a/src/main/java/com/assignment/phoneinventory/es/TelephoneNumberDocument.java
+++ b/src/main/java/com/assignment/phoneinventory/es/TelephoneNumberDocument.java
@@ -1,0 +1,79 @@
+package com.assignment.phoneinventory.es;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+import com.assignment.phoneinventory.domain.TelephoneNumber;
+
+@Document(indexName = "telephone_numbers")
+@Setting(settingPath = "/elasticsearch/telephone-settings.json")
+public class TelephoneNumberDocument {
+
+    @Id
+    private String id; // prefer DB id; fallback to number
+
+    @Field(type = FieldType.Text, analyzer = "standard")
+    private String number;
+
+    @Field(type = FieldType.Keyword)
+    private String countryCode;
+
+    @Field(type = FieldType.Keyword)
+    private String areaCode;
+
+    @Field(type = FieldType.Keyword)
+    private String prefix;
+
+    @Field(type = FieldType.Keyword)
+    private String status;
+
+    @Field(name = "numberDigits", type = FieldType.Text, analyzer = "digits_analyzer")
+    private String numberDigits;
+
+    public static TelephoneNumberDocument from(TelephoneNumber t) {
+        TelephoneNumberDocument d = new TelephoneNumberDocument();
+        d.id = t.getId() != null ? String.valueOf(t.getId()) : t.getNumber();
+        d.number = t.getNumber();
+        d.countryCode = t.getCountryCode();
+        d.areaCode = t.getAreaCode();
+        d.prefix = t.getPrefix();
+        d.status = t.getStatus() == null ? null : t.getStatus().name();
+        d.numberDigits = t.getNumberDigits();
+        return d;
+    }
+
+    public TelephoneNumber toDomain() {
+        TelephoneNumber t = new TelephoneNumber();
+        if (id != null) {
+            try { t.setId(Long.parseLong(id)); } catch (NumberFormatException ignored) {}
+        }
+        t.setNumber(number);
+        t.setCountryCode(countryCode);
+        t.setAreaCode(areaCode);
+        t.setPrefix(prefix);
+        if (status != null) {
+            t.setStatus(TelephoneNumber.Status.valueOf(status));
+        }
+        t.setNumberDigits(numberDigits);
+        return t;
+    }
+
+    // getters and setters
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+    public String getNumber() { return number; }
+    public void setNumber(String number) { this.number = number; }
+    public String getCountryCode() { return countryCode; }
+    public void setCountryCode(String countryCode) { this.countryCode = countryCode; }
+    public String getAreaCode() { return areaCode; }
+    public void setAreaCode(String areaCode) { this.areaCode = areaCode; }
+    public String getPrefix() { return prefix; }
+    public void setPrefix(String prefix) { this.prefix = prefix; }
+    public String getStatus() { return status; }
+    public void setStatus(String status) { this.status = status; }
+    public String getNumberDigits() { return numberDigits; }
+    public void setNumberDigits(String numberDigits) { this.numberDigits = numberDigits; }
+}

--- a/src/main/java/com/assignment/phoneinventory/service/TelephoneSearchService.java
+++ b/src/main/java/com/assignment/phoneinventory/service/TelephoneSearchService.java
@@ -1,0 +1,70 @@
+package com.assignment.phoneinventory.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.Operator;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.springframework.stereotype.Service;
+
+import com.assignment.phoneinventory.dao.TelephoneNumberDao;
+import com.assignment.phoneinventory.domain.TelephoneNumber;
+import com.assignment.phoneinventory.dto.PageResponse;
+import com.assignment.phoneinventory.es.TelephoneNumberDocument;
+
+@Service
+public class TelephoneSearchService {
+
+    private final ElasticsearchOperations operations;
+    private final TelephoneNumberDao jdbcDao;
+
+    public TelephoneSearchService(ElasticsearchOperations operations, TelephoneNumberDao jdbcDao) {
+        this.operations = operations;
+        this.jdbcDao = jdbcDao;
+    }
+
+    public PageResponse<TelephoneNumber> search(String cc, String ac, String prefix, String contains,
+                                                TelephoneNumber.Status status, int page, int size,
+                                                boolean fuzzy, boolean wildcard) {
+        try {
+            BoolQueryBuilder bool = QueryBuilders.boolQuery();
+            if (cc != null && !cc.isEmpty()) bool.filter(QueryBuilders.termQuery("countryCode", cc));
+            if (ac != null && !ac.isEmpty()) bool.filter(QueryBuilders.termQuery("areaCode", ac));
+            if (prefix != null && !prefix.isEmpty()) bool.filter(QueryBuilders.termQuery("prefix", prefix));
+            if (status != null) bool.filter(QueryBuilders.termQuery("status", status.name()));
+
+            if (contains != null && !contains.isEmpty()) {
+                if (contains.matches("\\d+")) {
+                    bool.must(QueryBuilders.prefixQuery("numberDigits", contains));
+                } else if (fuzzy) {
+                    bool.must(QueryBuilders.matchQuery("number", contains).fuzziness("AUTO"));
+                } else if (wildcard) {
+                    bool.must(QueryBuilders.wildcardQuery("number", "*" + contains + "*"));
+                } else {
+                    bool.must(QueryBuilders.matchQuery("number", contains).operator(Operator.AND));
+                }
+            }
+
+            NativeSearchQueryBuilder builder = new NativeSearchQueryBuilder()
+                    .withQuery(bool)
+                    .withPageable(PageRequest.of(page, size));
+            SearchHits<TelephoneNumberDocument> hits = operations.search(builder.build(), TelephoneNumberDocument.class);
+            List<TelephoneNumber> content = hits.getSearchHits().stream()
+                    .map(SearchHit::getContent)
+                    .map(TelephoneNumberDocument::toDomain)
+                    .collect(Collectors.toList());
+            long total = hits.getTotalHits();
+            return new PageResponse<>(content, page, size, total);
+        } catch (Exception ex) {
+            List<TelephoneNumber> rows = jdbcDao.search(cc, ac, prefix, contains, status == null ? null : status.name(), page, size);
+            long count = jdbcDao.count(cc, ac, prefix, contains, status == null ? null : status.name());
+            return new PageResponse<>(rows, page, size, count);
+        }
+    }
+}

--- a/src/main/resources/elasticsearch/telephone-settings.json
+++ b/src/main/resources/elasticsearch/telephone-settings.json
@@ -1,0 +1,18 @@
+{
+  "analysis": {
+    "analyzer": {
+      "digits_analyzer": {
+        "type": "custom",
+        "tokenizer": "keyword",
+        "filter": ["digits_only"]
+      }
+    },
+    "filter": {
+      "digits_only": {
+        "type": "pattern_replace",
+        "pattern": "\\D",
+        "replacement": ""
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Spring Data Elasticsearch dependency and configuration with index auto-creation
- map TelephoneNumber documents with custom digit analyzer and index updates via events
- introduce TelephoneSearchService using Elasticsearch with JDBC fallback and new controller options

## Testing
- `mvn -q -e test` *(fails: Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:2.7.18 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ae0085c8b8832693537684d5141213