### PR TITLE
Use phone numbers instead of IDs for phone operations

### DIFF
--- a/src/main/java/com/assignment/phoneinventory/controller/TelephoneController.java
+++ b/src/main/java/com/assignment/phoneinventory/controller/TelephoneController.java
@@ -76,30 +76,30 @@ public class TelephoneController {
         return ResponseEntity.ok(jobStatusMapper.from(execution));
     }
 
-    @PostMapping("/{id}/reserve")
+    @PostMapping("/{number}/reserve")
     @Operation(summary = "Reserve a number for a user for a given hold duration (minutes)")
-    public TelephoneNumber reserve(@PathVariable Long id,
+    public TelephoneNumber reserve(@PathVariable String number,
                                    @RequestParam String userId,
                                    @RequestParam(defaultValue = "30") int minutes) {
-        return service.reserve(id, userId, Duration.ofMinutes(minutes));
+        return service.reserve(number, userId, Duration.ofMinutes(minutes));
     }
 
-    @PostMapping("/{id}/allocate")
+    @PostMapping("/{number}/allocate")
     @Operation(summary = "Allocate a reserved number to the user")
-    public TelephoneNumber allocate(@PathVariable Long id, @RequestParam String userId) {
-        return service.allocate(id, userId);
+    public TelephoneNumber allocate(@PathVariable String number, @RequestParam String userId) {
+        return service.allocate(number, userId);
     }
 
-    @PostMapping("/{id}/activate")
+    @PostMapping("/{number}/activate")
     @Operation(summary = "Activate an allocated number")
-    public TelephoneNumber activate(@PathVariable Long id, @RequestParam String userId) {
-        return service.activate(id, userId);
+    public TelephoneNumber activate(@PathVariable String number, @RequestParam String userId) {
+        return service.activate(number, userId);
     }
 
-    @PostMapping("/{id}/deactivate")
+    @PostMapping("/{number}/deactivate")
     @Operation(summary = "Deactivate a number")
-    public TelephoneNumber deactivate(@PathVariable Long id, @RequestParam String userId) {
-        return service.deactivate(id, userId);
+    public TelephoneNumber deactivate(@PathVariable String number, @RequestParam String userId) {
+        return service.deactivate(number, userId);
     }
 
     @GetMapping("/jobs/{executionId}")

--- a/src/main/java/com/assignment/phoneinventory/dao/TelephoneNumberDao.java
+++ b/src/main/java/com/assignment/phoneinventory/dao/TelephoneNumberDao.java
@@ -55,6 +55,11 @@ public class TelephoneNumberDao {
         return list.isEmpty() ? Optional.empty() : Optional.of(list.get(0));
     }
 
+    public Optional<TelephoneNumber> findByNumber(String number) {
+        List<TelephoneNumber> list = jdbc.query(SELECT_BY_NUMBER, ROW_MAPPER, number);
+        return list.isEmpty() ? Optional.empty() : Optional.of(list.get(0));
+    }
+
     /**
      * Optimized search:
      * - If 'contains' is all digits, use number_digits LIKE 'digits%'.

--- a/src/main/java/com/assignment/phoneinventory/dao/TelephoneSql.java
+++ b/src/main/java/com/assignment/phoneinventory/dao/TelephoneSql.java
@@ -23,6 +23,10 @@ public final class TelephoneSql {
     public static final String SELECT_BY_ID =
             "SELECT " + SELECT_COLUMNS + " FROM " + TABLE + " WHERE " + ID + " = ?";
 
+    // Find by phone number
+    public static final String SELECT_BY_NUMBER =
+            "SELECT " + SELECT_COLUMNS + " FROM " + TABLE + " WHERE " + NUMBER + " = ?";
+
     // Pagination tail
     public static final String SEARCH_ORDER_LIMIT_OFFSET =
             " ORDER BY " + ID + " ASC LIMIT ? OFFSET ?";

--- a/src/main/java/com/assignment/phoneinventory/service/TelephoneService.java
+++ b/src/main/java/com/assignment/phoneinventory/service/TelephoneService.java
@@ -40,9 +40,9 @@ public class TelephoneService {
         return new PageResponse<>(rows, page, size, count);
     }
 
-    private TelephoneNumber getOrThrow(Long id) {
-        Optional<TelephoneNumber> opt = telDao.findById(id);
-        return opt.orElseThrow(() -> new ResourceNotFoundException("Number id=" + id + " not found"));
+    private TelephoneNumber getOrThrow(String number) {
+        Optional<TelephoneNumber> opt = telDao.findByNumber(number);
+        return opt.orElseThrow(() -> new ResourceNotFoundException("Number " + number + " not found"));
     }
 
     private void writeAudit(TelephoneNumber before, TelephoneNumber after, String userId, String note) {
@@ -57,8 +57,8 @@ public class TelephoneService {
     }
 
     @Transactional
-    public TelephoneNumber reserve(Long id, String userId, Duration hold) {
-        TelephoneNumber tn = getOrThrow(id);
+    public TelephoneNumber reserve(String number, String userId, Duration hold) {
+        TelephoneNumber tn = getOrThrow(number);
         if (tn.getStatus() != TelephoneNumber.Status.AVAILABLE) {
             throw new BusinessRuleViolationException("Only AVAILABLE numbers can be reserved");
         }
@@ -66,17 +66,17 @@ public class TelephoneService {
         next.setStatus(TelephoneNumber.Status.RESERVED);
         next.setAllocatedUserId(userId);
         next.setReservedUntil(Instant.now().plus(hold));
-        int updated = telDao.updateWithVersion(id, tn.getVersion(), next);
+        int updated = telDao.updateWithVersion(tn.getId(), tn.getVersion(), next);
         if (updated == 0) {
             throw new IllegalStateException("Concurrent update detected");
         }
         writeAudit(tn, next, userId, "Reserved for " + hold.toMinutes() + " min");
-        return getOrThrow(id);
+        return getOrThrow(number);
     }
 
     @Transactional
-    public TelephoneNumber allocate(Long id, String userId) {
-        TelephoneNumber tn = getOrThrow(id);
+    public TelephoneNumber allocate(String number, String userId) {
+        TelephoneNumber tn = getOrThrow(number);
         if (tn.getReservedUntil() != null && tn.getReservedUntil().isBefore(Instant.now())) {
             throw new IllegalStateException("Reservation expired");
         }
@@ -90,44 +90,44 @@ public class TelephoneService {
         next.setStatus(TelephoneNumber.Status.ALLOCATED);
         // keep allocatedUserId; clear reservedUntil
         next.setReservedUntil(null);
-        int updated = telDao.updateWithVersion(id, tn.getVersion(), next);
+        int updated = telDao.updateWithVersion(tn.getId(), tn.getVersion(), next);
         if (updated == 0) {
             throw new IllegalStateException("Concurrent update detected");
         }
         writeAudit(tn, next, userId, "Allocated");
-        return getOrThrow(id);
+        return getOrThrow(number);
     }
 
     @Transactional
-    public TelephoneNumber activate(Long id, String userId) {
-        TelephoneNumber tn = getOrThrow(id);
+    public TelephoneNumber activate(String number, String userId) {
+        TelephoneNumber tn = getOrThrow(number);
         if (tn.getStatus() != TelephoneNumber.Status.ALLOCATED) {
             throw new BusinessRuleViolationException("Only ALLOCATED numbers can be activated");
         }
         TelephoneNumber next = cloneState(tn);
         next.setStatus(TelephoneNumber.Status.ACTIVATED);
-        int updated = telDao.updateWithVersion(id, tn.getVersion(), next);
+        int updated = telDao.updateWithVersion(tn.getId(), tn.getVersion(), next);
         if (updated == 0) {
             throw new IllegalStateException("Concurrent update detected");
         }
         writeAudit(tn, next, userId, "Activated");
-        return getOrThrow(id);
+        return getOrThrow(number);
     }
 
     @Transactional
-    public TelephoneNumber deactivate(Long id, String userId) {
-        TelephoneNumber tn = getOrThrow(id);
+    public TelephoneNumber deactivate(String number, String userId) {
+        TelephoneNumber tn = getOrThrow(number);
         if (tn.getStatus() != TelephoneNumber.Status.ACTIVATED) {
             throw new BusinessRuleViolationException("Only ACTIVATED numbers can be deactivated");
         }
         TelephoneNumber next = cloneState(tn);
         next.setStatus(TelephoneNumber.Status.DEACTIVATED);
-        int updated = telDao.updateWithVersion(id, tn.getVersion(), next);
+        int updated = telDao.updateWithVersion(tn.getId(), tn.getVersion(), next);
         if (updated == 0) {
             throw new IllegalStateException("Concurrent update detected");
         }
         writeAudit(tn, next, userId, "Deactivated");
-        return getOrThrow(id);
+        return getOrThrow(number);
     }
 
     private static TelephoneNumber cloneState(TelephoneNumber src) {


### PR DESCRIPTION
## Summary
- Handle reserve/allocate/activate/deactivate operations by phone number rather than internal ID
- Add DAO lookup and SQL query for phone numbers
- Update service and controller layers to operate using phone numbers

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aea5f1c3dc8326b5d4be7bbd729974