### PR TITLE
Add digits prefix search option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ H2 console: http://localhost:8080/h2-console (JDBC URL: `jdbc:h2:mem:phones`)
 
 ## Endpoints
 - `POST /api/numbers/upload` — multipart `file` (CSV with header: `number,countryCode,areaCode,prefix`)
-- `GET /api/numbers/search?countryCode=&areaCode=&prefix=&contains=&status=&page=&size=`
+- `GET /api/numbers/search?countryCode=&areaCode=&prefix=&digitsPrefix=&contains=&status=&page=&size=`
 - `POST /api/numbers/{id}/reserve?userId=U123&minutes=15`
 - `POST /api/numbers/{id}/allocate?userId=U123`
 - `POST /api/numbers/{id}/activate?userId=U123`

--- a/src/main/java/com/assignment/phoneinventory/controller/TelephoneController.java
+++ b/src/main/java/com/assignment/phoneinventory/controller/TelephoneController.java
@@ -51,11 +51,12 @@ public class TelephoneController {
             @RequestParam(required = false) String countryCode,
             @RequestParam(required = false) String areaCode,
             @RequestParam(required = false) String prefix,
+            @RequestParam(required = false) String digitsPrefix,
             @RequestParam(required = false) String contains,
             @RequestParam(required = false) TelephoneNumber.Status status,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
-        return service.search(countryCode, areaCode, prefix, contains, status, page, size);
+        return service.search(countryCode, areaCode, prefix, digitsPrefix, contains, status, page, size);
     }
 
     @PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/assignment/phoneinventory/dao/TelephoneNumberDao.java
+++ b/src/main/java/com/assignment/phoneinventory/dao/TelephoneNumberDao.java
@@ -62,29 +62,23 @@ public class TelephoneNumberDao {
 
     /**
      * Optimized search:
-     * - If 'contains' is all digits, use number_digits LIKE 'digits%'.
-     * - Otherwise fallback to number LIKE '%contains%'.
+     * - digitsPrefix performs number_digits LIKE 'digits%'.
+     * - contains performs number LIKE '%contains%'.
      * - Other filters (cc/ac/prefix/status) unchanged.
      * - ORDER BY id ASC LIMIT/OFFSET preserved to avoid API breakage.
      */
-    public List<TelephoneNumber> search(String cc, String ac, String prefix, String contains, String status, int page, int size) {
+    public List<TelephoneNumber> search(String cc, String ac, String prefix, String digitsPrefix, String contains, String status, int page, int size) {
         StringBuilder sql = new StringBuilder(SELECT_BASE); // "... FROM telephone_numbers WHERE 1=1"
         List<Object> args = new ArrayList<>();
 
         if (cc != null && !cc.isEmpty()) { sql.append(" AND country_code = ?"); args.add(cc); }
         if (ac != null && !ac.isEmpty()) { sql.append(" AND area_code = ?"); args.add(ac); }
         if (prefix != null && !prefix.isEmpty()) { sql.append(" AND prefix = ?"); args.add(prefix); }
+        if (digitsPrefix != null && !digitsPrefix.isEmpty()) { sql.append(" AND number_digits LIKE ?"); args.add(digitsPrefix + "%"); }
 
         if (contains != null && !contains.isEmpty()) {
-            if (contains.matches("\\d+")) {
-                // digits-only -> fast prefix search on number_digits
-                sql.append(" AND number_digits LIKE ?");
-                args.add(contains + "%");
-            } else {
-                // fallback substring search
-                sql.append(" AND number LIKE ?");
-                args.add("%" + contains + "%");
-            }
+            sql.append(" AND number LIKE ?");
+            args.add("%" + contains + "%");
         }
 
         if (status != null && !status.isEmpty()) { sql.append(" AND status = ?"); args.add(status); }
@@ -96,22 +90,18 @@ public class TelephoneNumberDao {
         return jdbc.query(sql.toString(), ROW_MAPPER, args.toArray());
     }
 
-    public long count(String cc, String ac, String prefix, String contains, String status) {
+    public long count(String cc, String ac, String prefix, String digitsPrefix, String contains, String status) {
         StringBuilder sql = new StringBuilder(COUNT_BASE); // "SELECT COUNT(*) FROM telephone_numbers WHERE 1=1"
         List<Object> args = new ArrayList<>();
 
         if (cc != null && !cc.isEmpty()) { sql.append(" AND country_code = ?"); args.add(cc); }
         if (ac != null && !ac.isEmpty()) { sql.append(" AND area_code = ?"); args.add(ac); }
         if (prefix != null && !prefix.isEmpty()) { sql.append(" AND prefix = ?"); args.add(prefix); }
+        if (digitsPrefix != null && !digitsPrefix.isEmpty()) { sql.append(" AND number_digits LIKE ?"); args.add(digitsPrefix + "%"); }
 
         if (contains != null && !contains.isEmpty()) {
-            if (contains.matches("\\d+")) {
-                sql.append(" AND number_digits LIKE ?");
-                args.add(contains + "%");
-            } else {
-                sql.append(" AND number LIKE ?");
-                args.add("%" + contains + "%");
-            }
+            sql.append(" AND number LIKE ?");
+            args.add("%" + contains + "%");
         }
 
         if (status != null && !status.isEmpty()) { sql.append(" AND status = ?"); args.add(status); }

--- a/src/main/java/com/assignment/phoneinventory/service/TelephoneService.java
+++ b/src/main/java/com/assignment/phoneinventory/service/TelephoneService.java
@@ -34,9 +34,9 @@ public class TelephoneService {
         this.auditDao = auditDao;
     }
 
-    public PageResponse<TelephoneNumber> search(String cc, String ac, String prefix, String contains, TelephoneNumber.Status status, int page, int size) {
-        java.util.List<TelephoneNumber> rows = telDao.search(cc, ac, prefix, contains, status == null ? null : status.name(), page, size);
-        long count = telDao.count(cc, ac, prefix, contains, status == null ? null : status.name());
+    public PageResponse<TelephoneNumber> search(String cc, String ac, String prefix, String digitsPrefix, String contains, TelephoneNumber.Status status, int page, int size) {
+        java.util.List<TelephoneNumber> rows = telDao.search(cc, ac, prefix, digitsPrefix, contains, status == null ? null : status.name(), page, size);
+        long count = telDao.count(cc, ac, prefix, digitsPrefix, contains, status == null ? null : status.name());
         return new PageResponse<>(rows, page, size, count);
     }
 


### PR DESCRIPTION
## Summary
- allow searching telephone numbers by new `digitsPrefix` parameter on `number_digits`
- remove special parsing of numeric `contains` values, always using substring match
- document updated search endpoint

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aea8f292688326ac6c05b8ef241f66