### PR TITLE
Broaden prefix search across full number

### DIFF
--- a/src/main/java/com/assignment/phoneinventory/dao/TelephoneNumberDao.java
+++ b/src/main/java/com/assignment/phoneinventory/dao/TelephoneNumberDao.java
@@ -62,9 +62,10 @@ public class TelephoneNumberDao {
 
     /**
      * Optimized search:
+     * - prefix matches the column "prefix" *or* the beginning of the full number and digits-only number.
      * - digitsPrefix performs number_digits LIKE 'digits%'.
      * - contains performs number LIKE '%contains%'.
-     * - Other filters (cc/ac/prefix/status) unchanged.
+     * - Other filters (cc/ac/status) unchanged.
      * - ORDER BY id ASC LIMIT/OFFSET preserved to avoid API breakage.
      */
     public List<TelephoneNumber> search(String cc, String ac, String prefix, String digitsPrefix, String contains, String status, int page, int size) {
@@ -73,7 +74,14 @@ public class TelephoneNumberDao {
 
         if (cc != null && !cc.isEmpty()) { sql.append(" AND country_code = ?"); args.add(cc); }
         if (ac != null && !ac.isEmpty()) { sql.append(" AND area_code = ?"); args.add(ac); }
-        if (prefix != null && !prefix.isEmpty()) { sql.append(" AND prefix = ?"); args.add(prefix); }
+        if (prefix != null && !prefix.isEmpty()) {
+            String like = prefix + "%";
+            String digits = prefix.replaceAll("\\D", "") + "%";
+            sql.append(" AND (prefix LIKE ? OR number LIKE ? OR number_digits LIKE ?)");
+            args.add(like);
+            args.add(like);
+            args.add(digits);
+        }
         if (digitsPrefix != null && !digitsPrefix.isEmpty()) { sql.append(" AND number_digits LIKE ?"); args.add(digitsPrefix + "%"); }
 
         if (contains != null && !contains.isEmpty()) {
@@ -96,7 +104,14 @@ public class TelephoneNumberDao {
 
         if (cc != null && !cc.isEmpty()) { sql.append(" AND country_code = ?"); args.add(cc); }
         if (ac != null && !ac.isEmpty()) { sql.append(" AND area_code = ?"); args.add(ac); }
-        if (prefix != null && !prefix.isEmpty()) { sql.append(" AND prefix = ?"); args.add(prefix); }
+        if (prefix != null && !prefix.isEmpty()) {
+            String like = prefix + "%";
+            String digits = prefix.replaceAll("\\D", "") + "%";
+            sql.append(" AND (prefix LIKE ? OR number LIKE ? OR number_digits LIKE ?)");
+            args.add(like);
+            args.add(like);
+            args.add(digits);
+        }
         if (digitsPrefix != null && !digitsPrefix.isEmpty()) { sql.append(" AND number_digits LIKE ?"); args.add(digitsPrefix + "%"); }
 
         if (contains != null && !contains.isEmpty()) {


### PR DESCRIPTION
## Summary
- allow prefix filter to match prefix column, full number, and digits-only number
- mirror logic in the count query for accurate pagination

## Testing
- `mvn -q test` *(fails: 'dependencies.dependency.version' missing: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aeabc08ff483269dd467c31fd98af2