### PR TITLE
Restrict number activation to allocated user

### DIFF
--- a/src/main/java/com/assignment/phoneinventory/service/TelephoneService.java
+++ b/src/main/java/com/assignment/phoneinventory/service/TelephoneService.java
@@ -104,6 +104,9 @@ public class TelephoneService {
         if (tn.getStatus() != TelephoneNumber.Status.ALLOCATED) {
             throw new BusinessRuleViolationException("Only ALLOCATED numbers can be activated");
         }
+        if (tn.getAllocatedUserId() == null || !tn.getAllocatedUserId().equals(userId)) {
+            throw new BusinessRuleViolationException("Number allocated to a different user");
+        }
         TelephoneNumber next = cloneState(tn);
         next.setStatus(TelephoneNumber.Status.ACTIVATED);
         int updated = telDao.updateWithVersion(tn.getId(), tn.getVersion(), next);

--- a/src/test/java/com/assignment/phoneinventory/service/TelephoneServiceTest.java
+++ b/src/test/java/com/assignment/phoneinventory/service/TelephoneServiceTest.java
@@ -1,0 +1,33 @@
+package com.assignment.phoneinventory.service;
+
+import com.assignment.phoneinventory.dao.TelephoneNumberDao;
+import com.assignment.phoneinventory.exception.BusinessRuleViolationException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+class TelephoneServiceTest {
+
+    @Autowired
+    private TelephoneService service;
+
+    @Autowired
+    private TelephoneNumberDao dao;
+
+    @Test
+    void activatingWithDifferentUserFails() {
+        String number = "5551234";
+        dao.upsertNumber(number, "1", "2", "3");
+        service.reserve(number, "userA", Duration.ofMinutes(15));
+        service.allocate(number, "userA");
+
+        assertThrows(BusinessRuleViolationException.class,
+                () -> service.activate(number, "userB"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- prevent activating a number that was allocated to another user
- add service test guarding against cross-user activation

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68af09474c9483268e0ebf7ded0bb8c9