### PR TITLE
Add Elasticsearch-backed phone number search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Phone Inventory Service — Spring JDBC (no Hibernate)
 
-**Java 11**, **Spring Boot 2.7.18**, **H2 in-memory**, **JdbcTemplate**.
+**Java 11**, **Spring Boot 2.7.18**, **H2 in-memory**, **JdbcTemplate**, **Elasticsearch**.
 
 ## Run
 ```bash
@@ -11,6 +11,7 @@ H2 console: http://localhost:8080/h2-console (JDBC URL: `jdbc:h2:mem:phones`)
 ## Endpoints
 - `POST /api/numbers/upload` — multipart `file` (CSV with header: `number,countryCode,areaCode,prefix`)
 - `GET /api/numbers/search?countryCode=&areaCode=&prefix=&contains=&status=&page=&size=`
+- `GET /api/phones/elastic?countryCode=&areaCode=&prefix=&contains=&status=` — optional search via Elasticsearch (database search above remains unchanged)
 - `POST /api/numbers/{id}/reserve?userId=U123&minutes=15`
 - `POST /api/numbers/{id}/allocate?userId=U123`
 - `POST /api/numbers/{id}/activate?userId=U123`

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
       <artifactId>springdoc-openapi-ui</artifactId>
       <version>1.7.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-elasticsearch</artifactId>
+      <version>3.5.5</version>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/src/main/java/com/assignment/phoneinventory/controller/TelephoneController.java
+++ b/src/main/java/com/assignment/phoneinventory/controller/TelephoneController.java
@@ -5,6 +5,7 @@ import com.assignment.phoneinventory.dto.JobStatusResponse;
 import com.assignment.phoneinventory.dto.PageResponse;
 import com.assignment.phoneinventory.mapper.JobStatusMapper;
 import com.assignment.phoneinventory.service.BatchJobService;
+import com.assignment.phoneinventory.service.TelephoneSearchService;
 import com.assignment.phoneinventory.service.TelephoneService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,6 +29,7 @@ import java.time.Duration;
 public class TelephoneController {
 
     private final TelephoneService service;
+    private final TelephoneSearchService searchService;
     private final JobLauncher jobLauncher;
     private final Job importJob;
     private final JobExplorer jobExplorer;
@@ -36,8 +38,9 @@ public class TelephoneController {
 
 
     @Autowired
-    public TelephoneController(TelephoneService service, JobLauncher jobLauncher, Job importJob, JobExplorer jobExplorer, JobStatusMapper jobStatusMapper, BatchJobService batchJobService) {
+    public TelephoneController(TelephoneService service, TelephoneSearchService searchService, JobLauncher jobLauncher, Job importJob, JobExplorer jobExplorer, JobStatusMapper jobStatusMapper, BatchJobService batchJobService) {
         this.service = service;
+        this.searchService = searchService;
         this.jobLauncher = jobLauncher;
         this.importJob = importJob;
         this.jobExplorer = jobExplorer;
@@ -56,6 +59,17 @@ public class TelephoneController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         return service.search(countryCode, areaCode, prefix, contains, status, page, size);
+    }
+
+    @GetMapping("/elastic")
+    @Operation(summary = "Search telephone numbers via Elasticsearch")
+    public Iterable<TelephoneNumber> searchElastic(
+            @RequestParam(required = false) String countryCode,
+            @RequestParam(required = false) String areaCode,
+            @RequestParam(required = false) String prefix,
+            @RequestParam(required = false) String contains,
+            @RequestParam(required = false) TelephoneNumber.Status status) {
+        return searchService.search(countryCode, areaCode, prefix, contains, status);
     }
 
     @PostMapping(path = "/upload", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/assignment/phoneinventory/search/TelephoneNumberDocument.java
+++ b/src/main/java/com/assignment/phoneinventory/search/TelephoneNumberDocument.java
@@ -1,0 +1,69 @@
+package com.assignment.phoneinventory.search;
+
+import java.time.Instant;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+
+import com.assignment.phoneinventory.domain.TelephoneNumber;
+
+@Document(indexName = "telephone_numbers")
+public class TelephoneNumberDocument {
+
+    @Id
+    private Long id;
+    private String number;
+    private String countryCode;
+    private String areaCode;
+    private String prefix;
+    private TelephoneNumber.Status status;
+    private String allocatedUserId;
+    private Instant reservedUntil;
+    private long version;
+    private String numberDigits;
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getNumber() { return number; }
+    public void setNumber(String number) { this.number = number; }
+
+    public String getCountryCode() { return countryCode; }
+    public void setCountryCode(String countryCode) { this.countryCode = countryCode; }
+
+    public String getAreaCode() { return areaCode; }
+    public void setAreaCode(String areaCode) { this.areaCode = areaCode; }
+
+    public String getPrefix() { return prefix; }
+    public void setPrefix(String prefix) { this.prefix = prefix; }
+
+    public TelephoneNumber.Status getStatus() { return status; }
+    public void setStatus(TelephoneNumber.Status status) { this.status = status; }
+
+    public String getAllocatedUserId() { return allocatedUserId; }
+    public void setAllocatedUserId(String allocatedUserId) { this.allocatedUserId = allocatedUserId; }
+
+    public Instant getReservedUntil() { return reservedUntil; }
+    public void setReservedUntil(Instant reservedUntil) { this.reservedUntil = reservedUntil; }
+
+    public long getVersion() { return version; }
+    public void setVersion(long version) { this.version = version; }
+
+    public String getNumberDigits() { return numberDigits; }
+    public void setNumberDigits(String numberDigits) { this.numberDigits = numberDigits; }
+
+    public TelephoneNumber toDomain() {
+        TelephoneNumber t = new TelephoneNumber();
+        t.setId(id);
+        t.setNumber(number);
+        t.setCountryCode(countryCode);
+        t.setAreaCode(areaCode);
+        t.setPrefix(prefix);
+        t.setStatus(status);
+        t.setAllocatedUserId(allocatedUserId);
+        t.setReservedUntil(reservedUntil);
+        t.setVersion(version);
+        t.setNumberDigits(numberDigits);
+        return t;
+    }
+}

--- a/src/main/java/com/assignment/phoneinventory/search/TelephoneNumberSearchRepository.java
+++ b/src/main/java/com/assignment/phoneinventory/search/TelephoneNumberSearchRepository.java
@@ -1,0 +1,13 @@
+package com.assignment.phoneinventory.search;
+
+import java.util.List;
+
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface TelephoneNumberSearchRepository extends ElasticsearchRepository<TelephoneNumberDocument, Long> {
+
+    List<TelephoneNumberDocument> findByNumberContaining(String number);
+}
+

--- a/src/main/java/com/assignment/phoneinventory/service/TelephoneSearchService.java
+++ b/src/main/java/com/assignment/phoneinventory/service/TelephoneSearchService.java
@@ -1,0 +1,49 @@
+package com.assignment.phoneinventory.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.assignment.phoneinventory.domain.TelephoneNumber;
+import com.assignment.phoneinventory.search.TelephoneNumberDocument;
+import com.assignment.phoneinventory.search.TelephoneNumberSearchRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TelephoneSearchService {
+
+    private final TelephoneNumberSearchRepository repository;
+
+    public TelephoneSearchService(TelephoneNumberSearchRepository repository) {
+        this.repository = repository;
+    }
+
+    public Iterable<TelephoneNumber> search(String countryCode,
+                                            String areaCode,
+                                            String prefix,
+                                            String contains,
+                                            TelephoneNumber.Status status) {
+        Iterable<TelephoneNumberDocument> docs =
+                (contains == null || contains.isEmpty())
+                        ? repository.findAll()
+                        : repository.findByNumberContaining(contains);
+
+        List<TelephoneNumber> numbers = new ArrayList<>();
+        for (TelephoneNumberDocument doc : docs) {
+            if (countryCode != null && !countryCode.equals(doc.getCountryCode())) {
+                continue;
+            }
+            if (areaCode != null && !areaCode.equals(doc.getAreaCode())) {
+                continue;
+            }
+            if (prefix != null && !prefix.equals(doc.getPrefix())) {
+                continue;
+            }
+            if (status != null && status != doc.getStatus()) {
+                continue;
+            }
+            numbers.add(doc.toDomain());
+        }
+        return numbers;
+    }
+}
+


### PR DESCRIPTION
## Summary
- decouple Elasticsearch indexing from the existing TelephoneNumber entity
- add Elasticsearch document, repository and service that map results back to the DB model
- document optional Elasticsearch search endpoint
- support filtering by country code, area code, prefix, status and number substring

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: The following artifacts could not be resolved: org.springframework.boot:spring-boot-dependencies:pom:2.7.18 (absent): Could not transfer artifact org.springframework.boot:spring-boot-dependencies:pom:2.7.18 from/to central: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b00518e68883269c7667a9f6be2df1