### PR TITLE
Keep Elasticsearch index synchronized with database changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 **Java 11**, **Spring Boot 2.7.18**, **H2 in-memory**, **JdbcTemplate**, **Elasticsearch**.
 
+## Elasticsearch
+
+An Elasticsearch node must be available before starting the service. It defaults to
+`http://localhost:9200`; to use a different instance, configure `spring.elasticsearch.uris`
+in your environment or `application.properties`.
+
+The application keeps the `telephone_numbers` index in sync with database changes. State
+transitions and batch uploads automatically update Elasticsearch.
+
 ## Run
 ```bash
 mvn spring-boot:run

--- a/src/main/java/com/assignment/phoneinventory/batch/JobAuditListener.java
+++ b/src/main/java/com/assignment/phoneinventory/batch/JobAuditListener.java
@@ -1,6 +1,7 @@
 package com.assignment.phoneinventory.batch;
 
 import com.assignment.phoneinventory.service.BatchJobService;
+import com.assignment.phoneinventory.search.ElasticsearchIndexer;
 import org.springframework.batch.core.BatchStatus;
 import org.springframework.batch.core.ChunkListener;
 import org.springframework.batch.core.ExitStatus;
@@ -18,13 +19,15 @@ import java.util.concurrent.ConcurrentHashMap;
 public class JobAuditListener implements JobExecutionListener, StepExecutionListener, ChunkListener {
 
     private final BatchJobService jobs;
+    private final ElasticsearchIndexer indexer;
 
     // Track last reported totals per job to send deltas in heartbeat
     private final Map<String, Integer> lastReadByJob  = new ConcurrentHashMap<>();
     private final Map<String, Integer> lastFailByJob  = new ConcurrentHashMap<>();
 
-    public JobAuditListener(BatchJobService jobs) {
+    public JobAuditListener(BatchJobService jobs, ElasticsearchIndexer indexer) {
         this.jobs = jobs;
+        this.indexer = indexer;
     }
 
     // --- JobExecutionListener ---
@@ -46,6 +49,7 @@ public class JobAuditListener implements JobExecutionListener, StepExecutionList
 
         if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
             jobs.complete(jobId);
+            indexer.reindexAll();
         } else {
             jobs.fail(jobId, jobExecution.getAllFailureExceptions().toString());
         }

--- a/src/main/java/com/assignment/phoneinventory/dao/TelephoneNumberDao.java
+++ b/src/main/java/com/assignment/phoneinventory/dao/TelephoneNumberDao.java
@@ -60,6 +60,10 @@ public class TelephoneNumberDao {
         return list.isEmpty() ? Optional.empty() : Optional.of(list.get(0));
     }
 
+    public List<TelephoneNumber> findAll() {
+        return jdbc.query(SELECT_BASE, ROW_MAPPER);
+    }
+
     
     public List<TelephoneNumber> search(String cc, String ac, String prefix, String contains, String status, int page, int size) {
         StringBuilder sql = new StringBuilder(SELECT_BASE); // "... FROM telephone_numbers WHERE 1=1"

--- a/src/main/java/com/assignment/phoneinventory/search/ElasticsearchIndexer.java
+++ b/src/main/java/com/assignment/phoneinventory/search/ElasticsearchIndexer.java
@@ -1,0 +1,40 @@
+package com.assignment.phoneinventory.search;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+import com.assignment.phoneinventory.dao.TelephoneNumberDao;
+import com.assignment.phoneinventory.domain.TelephoneNumber;
+
+@Component
+public class ElasticsearchIndexer implements ApplicationRunner {
+
+    private final TelephoneNumberDao dao;
+    private final TelephoneNumberSearchRepository repo;
+
+    public ElasticsearchIndexer(TelephoneNumberDao dao, TelephoneNumberSearchRepository repo) {
+        this.dao = dao;
+        this.repo = repo;
+    }
+
+    @Override
+    public void run(ApplicationArguments args) {
+        reindexAll();
+    }
+
+    public void index(TelephoneNumber t) {
+        repo.save(TelephoneNumberDocument.from(t));
+    }
+
+    public void reindexAll() {
+        List<TelephoneNumberDocument> docs = dao.findAll().stream()
+                .map(TelephoneNumberDocument::from)
+                .collect(Collectors.toList());
+        repo.saveAll(docs);
+    }
+}
+

--- a/src/main/java/com/assignment/phoneinventory/search/TelephoneNumberDocument.java
+++ b/src/main/java/com/assignment/phoneinventory/search/TelephoneNumberDocument.java
@@ -52,6 +52,21 @@ public class TelephoneNumberDocument {
     public String getNumberDigits() { return numberDigits; }
     public void setNumberDigits(String numberDigits) { this.numberDigits = numberDigits; }
 
+    public static TelephoneNumberDocument from(TelephoneNumber t) {
+        TelephoneNumberDocument d = new TelephoneNumberDocument();
+        d.setId(t.getId());
+        d.setNumber(t.getNumber());
+        d.setCountryCode(t.getCountryCode());
+        d.setAreaCode(t.getAreaCode());
+        d.setPrefix(t.getPrefix());
+        d.setStatus(t.getStatus());
+        d.setAllocatedUserId(t.getAllocatedUserId());
+        d.setReservedUntil(t.getReservedUntil());
+        d.setVersion(t.getVersion());
+        d.setNumberDigits(t.getNumberDigits());
+        return d;
+    }
+
     public TelephoneNumber toDomain() {
         TelephoneNumber t = new TelephoneNumber();
         t.setId(id);

--- a/src/main/java/com/assignment/phoneinventory/service/TelephoneService.java
+++ b/src/main/java/com/assignment/phoneinventory/service/TelephoneService.java
@@ -9,6 +9,7 @@ import com.assignment.phoneinventory.dto.UploadResult;
 import com.assignment.phoneinventory.exception.BusinessRuleViolationException;
 import com.assignment.phoneinventory.exception.InvalidCsvFormatException;
 import com.assignment.phoneinventory.exception.ResourceNotFoundException;
+import com.assignment.phoneinventory.search.ElasticsearchIndexer;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,10 +29,12 @@ public class TelephoneService {
 
     private final TelephoneNumberDao telDao;
     private final AuditLogDao auditDao;
+    private final ElasticsearchIndexer indexer;
 
-    public TelephoneService(TelephoneNumberDao telDao, AuditLogDao auditDao) {
+    public TelephoneService(TelephoneNumberDao telDao, AuditLogDao auditDao, ElasticsearchIndexer indexer) {
         this.telDao = telDao;
         this.auditDao = auditDao;
+        this.indexer = indexer;
     }
 
     public PageResponse<TelephoneNumber> search(String cc, String ac, String prefix, String contains, TelephoneNumber.Status status, int page, int size) {
@@ -71,7 +74,9 @@ public class TelephoneService {
             throw new IllegalStateException("Concurrent update detected");
         }
         writeAudit(tn, next, userId, "Reserved for " + hold.toMinutes() + " min");
-        return getOrThrow(number);
+        TelephoneNumber result = getOrThrow(number);
+        indexer.index(result);
+        return result;
     }
 
     @Transactional
@@ -95,7 +100,9 @@ public class TelephoneService {
             throw new IllegalStateException("Concurrent update detected");
         }
         writeAudit(tn, next, userId, "Allocated");
-        return getOrThrow(number);
+        TelephoneNumber result = getOrThrow(number);
+        indexer.index(result);
+        return result;
     }
 
     @Transactional
@@ -114,7 +121,9 @@ public class TelephoneService {
             throw new IllegalStateException("Concurrent update detected");
         }
         writeAudit(tn, next, userId, "Activated");
-        return getOrThrow(number);
+        TelephoneNumber result = getOrThrow(number);
+        indexer.index(result);
+        return result;
     }
 
     @Transactional
@@ -130,7 +139,9 @@ public class TelephoneService {
             throw new IllegalStateException("Concurrent update detected");
         }
         writeAudit(tn, next, userId, "Deactivated");
-        return getOrThrow(number);
+        TelephoneNumber result = getOrThrow(number);
+        indexer.index(result);
+        return result;
     }
 
     private static TelephoneNumber cloneState(TelephoneNumber src) {
@@ -172,6 +183,7 @@ public class TelephoneService {
         long proc = processed.get();
         long ins = inserted.get();
         long skipped = proc - ins;
+        indexer.reindexAll();
         return new UploadResult(proc, ins, skipped);
     }
 }


### PR DESCRIPTION
## Summary
- Extend indexer to support single record updates and full reindex
- Automatically index telephone number state changes and reindex after bulk imports
- Document automatic sync in README

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b02ec04a888326a1b7bbddde9a66ec