### PR TITLE
fix: add H2-compatible merge upsert

### DIFF
--- a/src/main/java/com/assignment/phoneinventory/batch/BatchConfig.java
+++ b/src/main/java/com/assignment/phoneinventory/batch/BatchConfig.java
@@ -45,22 +45,52 @@ public class BatchConfig {
 
 
     @Bean
-    public JdbcBatchItemWriter<PhoneCsv> writer(DataSource dataSource) {
+    public JdbcBatchItemWriter<PhoneCsv> writer(DataSource dataSource) throws Exception {
         JdbcBatchItemWriter<PhoneCsv> writer = new JdbcBatchItemWriter<>();
         writer.setItemSqlParameterSourceProvider(new BeanPropertyItemSqlParameterSourceProvider<>());
         writer.setAssertUpdates(false); // allow no-op when row unchanged
-        // MySQL upsert using INSERT ... ON DUPLICATE KEY UPDATE with conditional assignments
-        writer.setSql(
-                "INSERT INTO telephone_numbers " +
-                        "(number, country_code, area_code, status, version, number_digits) " +
-                        "VALUES (:number, :countryCode, :areaCode, 'AVAILABLE', 0, :numberDigits) " +
-                        "ON DUPLICATE KEY UPDATE " +
-                        "country_code = IF(VALUES(country_code) <> country_code, VALUES(country_code), country_code), " +
-                        "area_code = IF(VALUES(area_code) <> area_code, VALUES(area_code), area_code), " +
-                        "status = IF(status <> 'AVAILABLE', 'AVAILABLE', status), " +
-                        "version = IF(version <> 0, 0, version), " +
-                        "number_digits = IF(VALUES(number_digits) <> number_digits, VALUES(number_digits), number_digits)"
-        );
+
+        String dbName;
+        try (java.sql.Connection conn = dataSource.getConnection()) {
+            dbName = conn.getMetaData().getDatabaseProductName();
+        }
+
+        if ("H2".equalsIgnoreCase(dbName)) {
+            // H2 upsert using MERGE with conditional update
+            writer.setSql(
+                    "MERGE INTO telephone_numbers t " +
+                            "USING (VALUES (:number, :countryCode, :areaCode, :numberDigits)) " +
+                            "s(number, country_code, area_code, number_digits) " +
+                            "ON t.number = s.number " +
+                            "WHEN MATCHED AND (" +
+                            "t.country_code IS DISTINCT FROM s.country_code OR " +
+                            "t.area_code IS DISTINCT FROM s.area_code OR " +
+                            "t.status <> 'AVAILABLE' OR " +
+                            "t.version <> 0 OR " +
+                            "t.number_digits IS DISTINCT FROM s.number_digits) THEN UPDATE SET " +
+                            "country_code = s.country_code, " +
+                            "area_code = s.area_code, " +
+                            "status = 'AVAILABLE', " +
+                            "version = 0, " +
+                            "number_digits = s.number_digits " +
+                            "WHEN NOT MATCHED THEN INSERT (number, country_code, area_code, status, version, number_digits) " +
+                            "VALUES (s.number, s.country_code, s.area_code, 'AVAILABLE', 0, s.number_digits)"
+            );
+        } else {
+            // MySQL upsert using INSERT ... ON DUPLICATE KEY UPDATE with conditional assignments
+            writer.setSql(
+                    "INSERT INTO telephone_numbers " +
+                            "(number, country_code, area_code, status, version, number_digits) " +
+                            "VALUES (:number, :countryCode, :areaCode, 'AVAILABLE', 0, :numberDigits) " +
+                            "ON DUPLICATE KEY UPDATE " +
+                            "country_code = IF(VALUES(country_code) <> country_code, VALUES(country_code), country_code), " +
+                            "area_code = IF(VALUES(area_code) <> area_code, VALUES(area_code), area_code), " +
+                            "status = IF(status <> 'AVAILABLE', 'AVAILABLE', status), " +
+                            "version = IF(version <> 0, 0, version), " +
+                            "number_digits = IF(VALUES(number_digits) <> number_digits, VALUES(number_digits), number_digits)"
+            );
+        }
+
         writer.setDataSource(dataSource);
         return writer;
     }


### PR DESCRIPTION
## Summary
- detect database type and use vendor-specific upsert
- add H2 MERGE upsert with conditions in WHEN MATCHED
- keep existing MySQL ON DUPLICATE KEY UPDATE behavior

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b26f1ca08326bf16ca92ffc97bb8