### PR TITLE
fix: add H2-compatible merge upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Phone Inventory Service — Spring JDBC (no Hibernate)
 
-**Java 11**, **Spring Boot 2.7.18**, **MySQL (Docker)**, **JdbcTemplate**, **Elasticsearch**.
+**Java 11**, **Spring Boot 2.7.18**, **H2 (default) / MySQL**, **JdbcTemplate**, **Elasticsearch**.
 
 ## Elasticsearch
 
@@ -12,20 +12,25 @@ The application keeps the `telephone_numbers` index in sync with database change
 transitions and batch uploads automatically update Elasticsearch.
 
 ## Run
-Start MySQL and Elasticsearch containers:
+Start the Elasticsearch container (required). The service defaults to an in-memory H2 database. If you prefer a persistent MySQL database, start MySQL as well and run the app with the `mysql` profile.
 ```bash
-docker-compose up -d mysql elasticsearch
+# Elasticsearch only
+docker-compose up -d elasticsearch
+
+# Optional: add MySQL
+docker-compose up -d mysql
 ```
-or run them manually:
+Or run them manually:
 ```bash
+# MySQL
 docker run --name phones-mysql \
   -e MYSQL_ROOT_PASSWORD=root \
   -e MYSQL_DATABASE=phones \
   -e MYSQL_USER=app \
   -e MYSQL_PASSWORD=app \
   -p 3306:3306 -d mysql:8
-```
-```bash
+
+# Elasticsearch
 docker run --name phones-es \
   -e discovery.type=single-node \
   -e xpack.security.enabled=false \
@@ -35,7 +40,11 @@ docker run --name phones-es \
 
 Run the service:
 ```bash
+# H2 (default)
 mvn spring-boot:run
+
+# MySQL
+SPRING_PROFILES_ACTIVE=mysql mvn spring-boot:run
 ```
 
 ## Endpoints
@@ -49,7 +58,7 @@ mvn spring-boot:run
 
 ## Batch Import
 - CSV numbers are normalized to digits-only `numberDigits` for consistent lookup
- - Uses MySQL `INSERT ... ON DUPLICATE KEY UPDATE` with conditional assignments to skip unchanged rows
+- Uses vendor-specific upsert (`MERGE` for H2, `INSERT ... ON DUPLICATE KEY UPDATE` for MySQL) with conditional assignments to skip unchanged rows
 - Step chunk size is configurable via `batch.chunk.size` (default `1000`)
 
 ## Design (Best Practices, No Hibernate)

--- a/pom.xml
+++ b/pom.xml
@@ -45,12 +45,11 @@
       <version>8.2.0</version>
       <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-      <version>2.2.224</version>
-      <scope>test</scope>
-    </dependency>
+      <dependency>
+        <groupId>com.h2database</groupId>
+        <artifactId>h2</artifactId>
+        <version>2.2.224</version>
+      </dependency>
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-core</artifactId>

--- a/src/main/java/com/assignment/phoneinventory/batch/BatchConfig.java
+++ b/src/main/java/com/assignment/phoneinventory/batch/BatchConfig.java
@@ -45,22 +45,52 @@ public class BatchConfig {
 
 
     @Bean
-    public JdbcBatchItemWriter<PhoneCsv> writer(DataSource dataSource) {
+    public JdbcBatchItemWriter<PhoneCsv> writer(DataSource dataSource) throws Exception {
         JdbcBatchItemWriter<PhoneCsv> writer = new JdbcBatchItemWriter<>();
         writer.setItemSqlParameterSourceProvider(new BeanPropertyItemSqlParameterSourceProvider<>());
         writer.setAssertUpdates(false); // allow no-op when row unchanged
-        // MySQL upsert using INSERT ... ON DUPLICATE KEY UPDATE with conditional assignments
-        writer.setSql(
-                "INSERT INTO telephone_numbers " +
-                        "(number, country_code, area_code, status, version, number_digits) " +
-                        "VALUES (:number, :countryCode, :areaCode, 'AVAILABLE', 0, :numberDigits) " +
-                        "ON DUPLICATE KEY UPDATE " +
-                        "country_code = IF(VALUES(country_code) <> country_code, VALUES(country_code), country_code), " +
-                        "area_code = IF(VALUES(area_code) <> area_code, VALUES(area_code), area_code), " +
-                        "status = IF(status <> 'AVAILABLE', 'AVAILABLE', status), " +
-                        "version = IF(version <> 0, 0, version), " +
-                        "number_digits = IF(VALUES(number_digits) <> number_digits, VALUES(number_digits), number_digits)"
-        );
+
+        String dbName;
+        try (java.sql.Connection conn = dataSource.getConnection()) {
+            dbName = conn.getMetaData().getDatabaseProductName();
+        }
+
+        if ("H2".equalsIgnoreCase(dbName)) {
+            // H2 upsert using MERGE with conditional update
+            writer.setSql(
+                    "MERGE INTO telephone_numbers t " +
+                            "USING (VALUES (:number, :countryCode, :areaCode, :numberDigits)) " +
+                            "s(number, country_code, area_code, number_digits) " +
+                            "ON t.number = s.number " +
+                            "WHEN MATCHED AND (" +
+                            "t.country_code IS DISTINCT FROM s.country_code OR " +
+                            "t.area_code IS DISTINCT FROM s.area_code OR " +
+                            "t.status <> 'AVAILABLE' OR " +
+                            "t.version <> 0 OR " +
+                            "t.number_digits IS DISTINCT FROM s.number_digits) THEN UPDATE SET " +
+                            "country_code = s.country_code, " +
+                            "area_code = s.area_code, " +
+                            "status = 'AVAILABLE', " +
+                            "version = 0, " +
+                            "number_digits = s.number_digits " +
+                            "WHEN NOT MATCHED THEN INSERT (number, country_code, area_code, status, version, number_digits) " +
+                            "VALUES (s.number, s.country_code, s.area_code, 'AVAILABLE', 0, s.number_digits)"
+            );
+        } else {
+            // MySQL upsert using INSERT ... ON DUPLICATE KEY UPDATE with conditional assignments
+            writer.setSql(
+                    "INSERT INTO telephone_numbers " +
+                            "(number, country_code, area_code, status, version, number_digits) " +
+                            "VALUES (:number, :countryCode, :areaCode, 'AVAILABLE', 0, :numberDigits) " +
+                            "ON DUPLICATE KEY UPDATE " +
+                            "country_code = IF(VALUES(country_code) <> country_code, VALUES(country_code), country_code), " +
+                            "area_code = IF(VALUES(area_code) <> area_code, VALUES(area_code), area_code), " +
+                            "status = IF(status <> 'AVAILABLE', 'AVAILABLE', status), " +
+                            "version = IF(version <> 0, 0, version), " +
+                            "number_digits = IF(VALUES(number_digits) <> number_digits, VALUES(number_digits), number_digits)"
+            );
+        }
+
         writer.setDataSource(dataSource);
         return writer;
     }

--- a/src/main/resources/application-mysql.properties
+++ b/src/main/resources/application-mysql.properties
@@ -1,0 +1,6 @@
+# DataSource (MySQL)
+spring.datasource.url=jdbc:mysql://localhost:3306/phones
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.username=app
+spring.datasource.password=app
+spring.h2.console.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,24 +1,21 @@
-# DataSource (MySQL via Docker)
-spring.datasource.url=jdbc:mysql://localhost:3306/phones
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.username=app
-spring.datasource.password=app
+## DataSource (H2 in-memory by default)
+spring.datasource.url=jdbc:h2:mem:phones;DB_CLOSE_DELAY=-1;MODE=MySQL
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.h2.console.enabled=true
 
 # liquibase
 spring.liquibase.change-log=classpath:db/changelog/db.changelog-master.xml
 
-
-# H2 console disabled when using MySQL
-
 spring.batch.job.enabled=false
 spring.batch.initialize-schema=always
 
-
-# CSV import batch step
+## CSV import batch step
 batch.chunk.size=1000
 
-# Web server
+## Web server
 server.port=8080
 
-# Logging
+## Logging
 logging.level.org.springframework.jdbc.core.JdbcTemplate=INFO


### PR DESCRIPTION
## Summary
- detect database type and use vendor-specific upsert
- add H2 MERGE upsert with conditions in WHEN MATCHED
- keep existing MySQL ON DUPLICATE KEY UPDATE behavior
- default datasource now uses in-memory H2 with optional MySQL profile

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b26f1ca08326bf16ca92ffc97bb8