### PR TITLE
Inject JobAuditListener into import batch workflow

### DIFF
--- a/src/main/java/com/assignment/phoneinventory/batch/BatchConfig.java
+++ b/src/main/java/com/assignment/phoneinventory/batch/BatchConfig.java
@@ -100,19 +100,22 @@ public class BatchConfig {
                            FlatFileItemReader<PhoneCsv> reader,
                            ItemProcessor<PhoneCsv, PhoneCsv> processor,
                            JdbcBatchItemWriter<PhoneCsv> writer,
+                           JobAuditListener jobAuditListener,
                            @Value("${batch.chunk.size:1000}") int chunkSize) {
         return stepBuilderFactory.get("importStep")
                 .<PhoneCsv, PhoneCsv>chunk(chunkSize)
                 .reader(reader)
                 .processor(processor)
                 .writer(writer)
+                .listener(jobAuditListener)
                 .build();
     }
 
     @Bean
-    public Job importJob(JobBuilderFactory jobBuilderFactory, Step importStep) {
+    public Job importJob(JobBuilderFactory jobBuilderFactory, Step importStep, JobAuditListener jobAuditListener) {
         return jobBuilderFactory.get("importJob")
                 .incrementer(new RunIdIncrementer())
+                .listener(jobAuditListener)
                 .flow(importStep)
                 .end()
                 .build();


### PR DESCRIPTION
## Summary
- add JobAuditListener to importStep and importJob
- ensure job and step flow invoke listener for Elasticsearch reindexing after CSV processing

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c25eb4f88326860dcdd713df4ef3