### PR TITLE
Handle reindexing when batch job lacks ID

### DIFF
--- a/src/main/java/com/assignment/phoneinventory/batch/JobAuditListener.java
+++ b/src/main/java/com/assignment/phoneinventory/batch/JobAuditListener.java
@@ -11,6 +11,7 @@ import org.springframework.batch.core.StepExecution;
 import org.springframework.batch.core.StepExecutionListener;
 import org.springframework.batch.core.scope.context.ChunkContext;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -35,7 +36,7 @@ public class JobAuditListener implements JobExecutionListener, StepExecutionList
     @Override
     public void beforeJob(JobExecution jobExecution) {
         String jobId = jobExecution.getJobParameters().getString("jobId");
-        if (jobId != null && !jobId.isBlank()) {
+        if (StringUtils.hasText(jobId)) {
             jobs.markRunning(jobId);
             lastReadByJob.put(jobId, 0);
             lastFailByJob.put(jobId, 0);
@@ -45,18 +46,20 @@ public class JobAuditListener implements JobExecutionListener, StepExecutionList
     @Override
     public void afterJob(JobExecution jobExecution) {
         String jobId = jobExecution.getJobParameters().getString("jobId");
-        if (jobId == null || jobId.isBlank()) return;
+        boolean hasJobId = StringUtils.hasText(jobId);
 
         if (jobExecution.getStatus() == BatchStatus.COMPLETED) {
-            jobs.complete(jobId);
+            if (hasJobId) jobs.complete(jobId);
             indexer.reindexAll();
-        } else {
+        } else if (hasJobId) {
             jobs.fail(jobId, jobExecution.getAllFailureExceptions().toString());
         }
 
         // cleanup to avoid leaks across runs
-        lastReadByJob.remove(jobId);
-        lastFailByJob.remove(jobId);
+        if (hasJobId) {
+            lastReadByJob.remove(jobId);
+            lastFailByJob.remove(jobId);
+        }
     }
 
     // --- StepExecutionListener ---
@@ -81,7 +84,7 @@ public class JobAuditListener implements JobExecutionListener, StepExecutionList
     @Override
     public void afterChunk(ChunkContext context) {
         String jobId = (String) context.getStepContext().getJobParameters().get("jobId");
-        if (jobId == null || jobId.isBlank()) return;
+        if (!StringUtils.hasText(jobId)) return;
 
         StepExecution se = context.getStepContext().getStepExecution();
 

--- a/src/test/java/com/assignment/phoneinventory/batch/BatchImportIntegrationTest.java
+++ b/src/test/java/com/assignment/phoneinventory/batch/BatchImportIntegrationTest.java
@@ -21,10 +21,16 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.IndexOperations;
 
 import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.assignment.phoneinventory.search.TelephoneNumberDocument;
+import com.assignment.phoneinventory.search.TelephoneNumberSearchRepository;
 
 @SpringBatchTest
 @SpringBootTest
@@ -37,12 +43,17 @@ class BatchImportIntegrationTest {
             .withUsername("app")
             .withPassword("app");
 
+    @Container
+    static ElasticsearchContainer elastic = new ElasticsearchContainer("docker.elastic.co/elasticsearch/elasticsearch:7.17.13")
+            .withEnv("discovery.type", "single-node");
+
     @DynamicPropertySource
     static void mysqlProps(DynamicPropertyRegistry registry) {
         registry.add("spring.datasource.url", mysql::getJdbcUrl);
         registry.add("spring.datasource.username", mysql::getUsername);
         registry.add("spring.datasource.password", mysql::getPassword);
         registry.add("spring.datasource.driver-class-name", mysql::getDriverClassName);
+        registry.add("spring.elasticsearch.rest.uris", elastic::getHttpHostAddress);
     }
 
     @Autowired
@@ -54,6 +65,12 @@ class BatchImportIntegrationTest {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    @Autowired
+    private ElasticsearchOperations operations;
+
+    @Autowired
+    private TelephoneNumberSearchRepository searchRepo;
+
     private JobLauncherTestUtils jobLauncherTestUtils;
 
     @TempDir
@@ -64,6 +81,12 @@ class BatchImportIntegrationTest {
         jobLauncherTestUtils = new JobLauncherTestUtils();
         jobLauncherTestUtils.setJobLauncher(jobLauncher);
         jobLauncherTestUtils.setJob(importJob);
+
+        IndexOperations indexOps = operations.indexOps(TelephoneNumberDocument.class);
+        if (indexOps.exists()) {
+            indexOps.delete();
+        }
+        indexOps.create();
     }
 
     private Path copyResource(String resourcePath) throws Exception {
@@ -106,6 +129,19 @@ class BatchImportIntegrationTest {
 
         assertThat(area1).isEqualTo("080"); // no-op update skipped
         assertThat(area2).isEqualTo("081"); // updated
+    }
+
+    @Test
+    void jobWithoutJobIdIndexesData() throws Exception {
+        Path file = copyResource("batch/phones_initial.csv");
+        JobParameters params = new JobParametersBuilder()
+                .addString("file.path", file.toString())
+                .toJobParameters();
+        JobExecution exec = jobLauncherTestUtils.launchJob(params);
+        assertThat(exec.getExitStatus().getExitCode()).isEqualTo("COMPLETED");
+
+        long indexed = searchRepo.count();
+        assertThat(indexed).isEqualTo(2L);
     }
 }
 


### PR DESCRIPTION
## Summary
- Always reindex search data after successful batch jobs even when no jobId is provided
- Guard job status updates and cleanup on presence of jobId
- Extend integration tests to verify indexing without jobId
- Refactor listener to centralize jobId checks with `StringUtils`

## Testing
- `mvn -q -U test` *(fails: Non-resolvable import POM: org.springframework.boot:spring-boot-dependencies 2.7.18, Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b5c86a8dc48326b702ead8411852bf