### PR TITLE
Remove number_digits column and related logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Java 11**, **Spring Boot 2.7.18**, **MySQL**, **Elasticsearch**, **JdbcTemplate**.
 
+Telephone numbers are stored as provided; the former `number_digits` column has been removed and digit-only search is computed on demand.
+
 ## Run
 The service requires MySQL and Elasticsearch. Start both services and then run the application.
 

--- a/src/main/java/com/assignment/phoneinventory/batch/ElasticsearchItemWriter.java
+++ b/src/main/java/com/assignment/phoneinventory/batch/ElasticsearchItemWriter.java
@@ -30,7 +30,6 @@ public class ElasticsearchItemWriter implements ItemWriter<PhoneCsv> {
             doc.setCountryCode(item.getCountryCode());
             doc.setAreaCode(item.getAreaCode());
             doc.setStatus("AVAILABLE");
-            doc.setNumberDigits(item.getNumberDigits());
             doc.setAllocatedUserId(item.getAllocatedUserId());
             doc.setReservedUntil(item.getReservedUntil());
             return doc;

--- a/src/main/java/com/assignment/phoneinventory/batch/PhoneCsv.java
+++ b/src/main/java/com/assignment/phoneinventory/batch/PhoneCsv.java
@@ -11,9 +11,6 @@ public class PhoneCsv {
     private String allocatedUserId;
     private Instant reservedUntil;
 
-    // Computed in ItemProcessor for fast search; persisted by writer as :numberDigits
-    private String numberDigits; // digits-only form of 'number' (e.g. "918079123456")
-
     public PhoneCsv() { }
 
     // ----- getters & setters (trim to be CSV-friendly) -----
@@ -32,9 +29,6 @@ public class PhoneCsv {
     public Instant getReservedUntil() { return reservedUntil; }
     public void setReservedUntil(Instant reservedUntil) { this.reservedUntil = reservedUntil; }
 
-    public String getNumberDigits() { return numberDigits; }
-    public void setNumberDigits(String numberDigits) { this.numberDigits = trimOrNull(numberDigits); }
-
     private static String trimOrNull(String s) {
         if (s == null) return null;
         String t = s.trim();
@@ -49,7 +43,6 @@ public class PhoneCsv {
                 ", areaCode='" + areaCode + '\'' +
                 ", allocatedUserId='" + allocatedUserId + '\'' +
                 ", reservedUntil='" + reservedUntil + '\'' +
-                ", numberDigits='" + numberDigits + '\'' +
                 '}';
     }
 }

--- a/src/main/java/com/assignment/phoneinventory/configs/BatchConfig.java
+++ b/src/main/java/com/assignment/phoneinventory/configs/BatchConfig.java
@@ -48,9 +48,6 @@ public class BatchConfig {
                 throw new InvalidCsvFormatException(CommonConstants.MISSING_REQUIRED_COLUMN);
             }
 
-            String digits = item.getNumber().replaceAll("\\D+", "");
-            item.setNumberDigits(digits);
-
             return item;
         };
     }

--- a/src/main/java/com/assignment/phoneinventory/constants/BatchJobConstants.java
+++ b/src/main/java/com/assignment/phoneinventory/constants/BatchJobConstants.java
@@ -28,13 +28,12 @@ public final class BatchJobConstants {
 
     public static final String UPSERT_TELEPHONE_NUMBER =
             "INSERT INTO telephone_numbers " +
-                    "(number, country_code, area_code, status, version, number_digits) " +
-                    "VALUES (:number, :countryCode, :areaCode, 'AVAILABLE', 0, :numberDigits) " +
+                    "(number, country_code, area_code, status, version) " +
+                    "VALUES (:number, :countryCode, :areaCode, 'AVAILABLE', 0) " +
                     "ON DUPLICATE KEY UPDATE " +
                     "country_code = IF(VALUES(country_code) <> country_code, VALUES(country_code), country_code), " +
                     "area_code = IF(VALUES(area_code) <> area_code, VALUES(area_code), area_code), " +
                     "status = IF(status <> 'AVAILABLE', 'AVAILABLE', status), " +
-                    "version = IF(version <> 0, 0, version), " +
-                    "number_digits = IF(VALUES(number_digits) <> number_digits, VALUES(number_digits), number_digits)";
+                    "version = IF(version <> 0, 0, version)";
 }
 

--- a/src/main/java/com/assignment/phoneinventory/constants/TelephoneConstants.java
+++ b/src/main/java/com/assignment/phoneinventory/constants/TelephoneConstants.java
@@ -12,7 +12,7 @@ public final class TelephoneConstants {
     public static final String SELECT_COLUMNS =
             String.join(",",
                 ID, NUMBER, COUNTRY_CODE, AREA_CODE, STATUS,
-                ALLOCATED_USER_ID, RESERVED_UNTIL, VERSION, NUMBER_DIGITS
+                ALLOCATED_USER_ID, RESERVED_UNTIL, VERSION
             );
 
     // Base select for searches (WHERE 1=1 tailors dynamically)
@@ -52,6 +52,6 @@ public final class TelephoneConstants {
     public static final String INSERT_ROW =
             "INSERT INTO " + TABLE + "(" +
                     String.join(",", NUMBER, COUNTRY_CODE, AREA_CODE, STATUS,
-                                      ALLOCATED_USER_ID, RESERVED_UNTIL, VERSION, NUMBER_DIGITS) +
-            ") VALUES (?,?,?,?,?,?,?,?)";
+                                      ALLOCATED_USER_ID, RESERVED_UNTIL, VERSION) +
+            ") VALUES (?,?,?,?,?,?,?)";
 }

--- a/src/main/java/com/assignment/phoneinventory/dao/TelephoneCols.java
+++ b/src/main/java/com/assignment/phoneinventory/dao/TelephoneCols.java
@@ -12,5 +12,4 @@ public final class TelephoneCols {
     public static final String ALLOCATED_USER_ID= "allocated_user_id";
     public static final String RESERVED_UNTIL   = "reserved_until";
     public static final String VERSION          = "version";
-    public static final String NUMBER_DIGITS    = "number_digits";
 }

--- a/src/main/java/com/assignment/phoneinventory/dao/TelephoneNumberDao.java
+++ b/src/main/java/com/assignment/phoneinventory/dao/TelephoneNumberDao.java
@@ -39,12 +39,6 @@ public class TelephoneNumberDao {
             Timestamp ts = rs.getTimestamp(RESERVED_UNTIL);
             t.setReservedUntil(ts == null ? null : ts.toInstant());
             t.setVersion(rs.getLong(VERSION));
-            // number_digits may not exist on very old DBs; map defensively
-            try {
-                t.setNumberDigits(rs.getString(NUMBER_DIGITS));
-            } catch (SQLException ignored) {
-                // column not present -> ignore
-            }
             return t;
         }
     };
@@ -128,9 +122,7 @@ public class TelephoneNumberDao {
                 t.getStatus().name(),
                 t.getAllocatedUserId(),
                 t.getReservedUntil() == null ? null : Timestamp.from(t.getReservedUntil()),
-                t.getVersion(),
-                // Persist normalized digits if your INSERT includes it
-                t.getNumberDigits()
+                t.getVersion()
         );
     }
 
@@ -146,10 +138,6 @@ public class TelephoneNumberDao {
         t.setAreaCode(ac);
         t.setStatus(TelephoneNumber.Status.AVAILABLE);
         t.setVersion(0);
-        // if your domain is computing numberDigits elsewhere, set it here as well
-        if (t.getNumber() != null) {
-            t.setNumberDigits(t.getNumber().replaceAll("\\D", ""));
-        }
         return insert(t);
     }
 }

--- a/src/main/java/com/assignment/phoneinventory/domain/TelephoneNumber.java
+++ b/src/main/java/com/assignment/phoneinventory/domain/TelephoneNumber.java
@@ -23,10 +23,6 @@ public class TelephoneNumber {
     @JsonIgnore
     private long version;
 
-    /** Digits-only normalized form of the number (e.g., "+91-8079-..." -> "918079...").
-     *  Used for fast search via the number_digits column. Optional for existing rows. */
-    @JsonIgnore
-    private String numberDigits;
 
     // --- getters/setters ---
 
@@ -55,6 +51,4 @@ public class TelephoneNumber {
     public long getVersion() { return version; }
     public void setVersion(long version) { this.version = version; }
 
-    public String getNumberDigits() { return numberDigits; }
-    public void setNumberDigits(String numberDigits) { this.numberDigits = numberDigits; }
 }

--- a/src/main/java/com/assignment/phoneinventory/search/TelephoneDocument.java
+++ b/src/main/java/com/assignment/phoneinventory/search/TelephoneDocument.java
@@ -13,7 +13,6 @@ public class TelephoneDocument {
     private String countryCode;
     private String areaCode;
     private String status;
-    private String numberDigits;
     private String allocatedUserId;
     @Field(type = FieldType.Date, format = DateFormat.epoch_millis)
     private Instant reservedUntil;
@@ -26,8 +25,6 @@ public class TelephoneDocument {
     public void setAreaCode(String areaCode) { this.areaCode = areaCode; }
     public String getStatus() { return status; }
     public void setStatus(String status) { this.status = status; }
-    public String getNumberDigits() { return numberDigits; }
-    public void setNumberDigits(String numberDigits) { this.numberDigits = numberDigits; }
     public String getAllocatedUserId() { return allocatedUserId; }
     public void setAllocatedUserId(String allocatedUserId) { this.allocatedUserId = allocatedUserId; }
     public Instant getReservedUntil() { return reservedUntil; }

--- a/src/main/java/com/assignment/phoneinventory/service/TelephoneService.java
+++ b/src/main/java/com/assignment/phoneinventory/service/TelephoneService.java
@@ -100,9 +100,6 @@ public class TelephoneService {
         if (tn.getStatus() != null) {
             doc.setStatus(tn.getStatus().name());
         }
-        if (tn.getNumber() != null) {
-            doc.setNumberDigits(tn.getNumber().replaceAll("\\D", ""));
-        }
         doc.setAllocatedUserId(tn.getAllocatedUserId());
         doc.setReservedUntil(tn.getReservedUntil());
         esOps.save(doc);

--- a/src/main/resources/db/changelog/002-optimize-search.xml
+++ b/src/main/resources/db/changelog/002-optimize-search.xml
@@ -4,14 +4,6 @@
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
          http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
 
-    <changeSet id="opt-3.1-number-digits" author="patch">
-        <addColumn tableName="telephone_numbers">
-            <column name="number_digits" type="VARCHAR(32)" defaultValue="">
-                <constraints nullable="false"/>
-            </column>
-        </addColumn>
-    </changeSet>
-
     <changeSet id="opt-3.2-comp-index" author="patch">
         <createIndex indexName="idx_tel_cc_ac_status_num"
                      tableName="telephone_numbers">
@@ -19,13 +11,6 @@
             <column name="area_code"/>
             <column name="status"/>
             <column name="number"/>
-        </createIndex>
-    </changeSet>
-
-    <changeSet id="opt-3.3-digits-index" author="patch">
-        <createIndex indexName="idx_tel_number_digits"
-                     tableName="telephone_numbers">
-            <column name="number_digits"/>
         </createIndex>
     </changeSet>
 

--- a/src/main/resources/db/changelog/004-remove-number-digits.xml
+++ b/src/main/resources/db/changelog/004-remove-number-digits.xml
@@ -1,0 +1,15 @@
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+         http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.8.xsd">
+
+    <changeSet id="rm-4.1-drop-number-digits" author="patch">
+        <preConditions onFail="MARK_RAN">
+            <columnExists tableName="telephone_numbers" columnName="number_digits"/>
+        </preConditions>
+        <dropIndex indexName="idx_tel_number_digits" tableName="telephone_numbers"/>
+        <dropColumn tableName="telephone_numbers" columnName="number_digits"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -7,4 +7,5 @@
     <include file="001-create-tables.xml" relativeToChangelogFile="true"/>
     <include file="002-optimize-search.xml" relativeToChangelogFile="true"/>
     <include file="003-batch-jobs.xml" relativeToChangelogFile="true"/>
+    <include file="004-remove-number-digits.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>


### PR DESCRIPTION
## Summary
- drop the number_digits column and index from schema and include migration to remove existing data
- remove numberDigits field from domain models, DTOs, DAO, and batch processing
- simplify upsert SQL and processing pipeline to work without numberDigits

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c1409faf408326ad93cd98939f6a20