### PR TITLE
Include jobId in job status response

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ If upgrading from an earlier version, drop and recreate the `phones` index or re
 
 ## Endpoints
 - `POST /api/phones/upload` — multipart `file` (CSV with header: `number,countryCode,areaCode`)
- - `GET /api/phones?countryCode=&areaCode=&contains=&status=&page=&size=`
+  Returns `{ "executionId": <id>, "jobId": "<job identifier>" }` for tracking.
+- `GET /api/phones?countryCode=&areaCode=&contains=&status=&page=&size=`
 - `POST /api/numbers/{id}/reserve?userId=U123&minutes=15`
 - `POST /api/numbers/{id}/allocate?userId=U123`
 - `POST /api/numbers/{id}/activate?userId=U123`

--- a/src/main/java/com/assignment/phoneinventory/dto/JobStatusResponse.java
+++ b/src/main/java/com/assignment/phoneinventory/dto/JobStatusResponse.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 public class JobStatusResponse {
     public long executionId;
+    public String jobId;
     public String jobName;
     public String status;
     public LocalDateTime startTime;
@@ -14,11 +15,12 @@ public class JobStatusResponse {
     public List<StepStatus> steps;
 
     public JobStatusResponse() {}
-    public JobStatusResponse(long executionId, String jobName, String status,
+    public JobStatusResponse(long executionId, String jobId, String jobName, String status,
                              LocalDateTime startTime, LocalDateTime endTime,
                              String exitCode, String exitDescription,
                              List<StepStatus> steps) {
         this.executionId = executionId;
+        this.jobId = jobId;
         this.jobName = jobName;
         this.status = status;
         this.startTime = startTime;

--- a/src/main/java/com/assignment/phoneinventory/mapper/JobStatusMapper.java
+++ b/src/main/java/com/assignment/phoneinventory/mapper/JobStatusMapper.java
@@ -1,5 +1,6 @@
 package com.assignment.phoneinventory.mapper;
 
+import com.assignment.phoneinventory.constants.CommonConstants;
 import com.assignment.phoneinventory.dto.JobStatusResponse;
 import com.assignment.phoneinventory.dto.StepStatus;
 import org.springframework.batch.core.JobExecution;
@@ -33,8 +34,11 @@ public class JobStatusMapper {
             ));
         }
 
+        String jobId = exec.getJobParameters().getString(CommonConstants.JOB_ID);
+
         return new JobStatusResponse(
                 exec.getId(),
+                jobId,
                 exec.getJobInstance().getJobName(),
                 exec.getStatus().toString(),
                 st,

--- a/src/test/java/com/assignment/phoneinventory/controller/TelephoneControllerTest.java
+++ b/src/test/java/com/assignment/phoneinventory/controller/TelephoneControllerTest.java
@@ -1,0 +1,76 @@
+package com.assignment.phoneinventory.controller;
+
+import com.assignment.phoneinventory.dto.JobStatusResponse;
+import com.assignment.phoneinventory.mapper.JobStatusMapper;
+import com.assignment.phoneinventory.service.BatchJobService;
+import com.assignment.phoneinventory.service.TelephoneService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobParameters;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.batch.core.explore.JobExplorer;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(TelephoneController.class)
+class TelephoneControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TelephoneService telephoneService;
+
+    @MockBean
+    private JobLauncher jobLauncher;
+
+    @MockBean
+    private Job importJob;
+
+    @MockBean
+    private JobExplorer jobExplorer;
+
+    @MockBean
+    private JobStatusMapper jobStatusMapper;
+
+    @MockBean
+    private BatchJobService batchJobService;
+
+    @Test
+    void uploadReturnsJobId() throws Exception {
+        String jobId = "job-123";
+        when(batchJobService.newJob(ArgumentMatchers.anyString())).thenReturn(jobId);
+
+        JobExecution exec = new JobExecution(1L);
+        when(jobLauncher.run(ArgumentMatchers.eq(importJob), ArgumentMatchers.any(JobParameters.class))).thenReturn(exec);
+
+        JobStatusResponse response = new JobStatusResponse(
+                exec.getId(), jobId, "importJob", "STARTING",
+                LocalDateTime.now(), null,
+                "", "", Collections.emptyList());
+        when(jobStatusMapper.from(exec)).thenReturn(response);
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "phones.csv", MediaType.TEXT_PLAIN_VALUE,
+                "number,countryCode,areaCode\n123,1,2".getBytes());
+
+        mockMvc.perform(multipart("/api/phones/upload").file(file))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.jobId").value(jobId))
+                .andExpect(jsonPath("$.executionId").value(1));
+    }
+}


### PR DESCRIPTION
## Summary
- add jobId to JobStatusResponse DTO and map it from job parameters
- document jobId in API upload response
- test upload endpoint returns jobId

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c16587844c8326b786e3b628468ae6